### PR TITLE
Main end island generation

### DIFF
--- a/src/main/java/com/fractalsmp/fractal_carpet_addon/FractalSimpleSettings.java
+++ b/src/main/java/com/fractalsmp/fractal_carpet_addon/FractalSimpleSettings.java
@@ -10,4 +10,10 @@ public class FractalSimpleSettings {
             category = {FractalSettingCategory, FEATURE}
     )
     public static boolean endGatewayCooldown = true;
+
+    @Rule(
+            desc = "Toggle for the main end island structure generation, turns off portal, egg, obsidian pillars, gateways and crystals",
+            category = {FractalSettingCategory, FEATURE}
+    )
+    public static boolean endMainIslandStructureGen = true;
 }

--- a/src/main/java/com/fractalsmp/fractal_carpet_addon/mixins/EndGateway_noCooldownMixin.java
+++ b/src/main/java/com/fractalsmp/fractal_carpet_addon/mixins/EndGateway_noCooldownMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(EndGatewayBlockEntity.class)
-public class EndGateway_noCooldownMixin extends EndPortalBlockEntity {
+public abstract class EndGateway_noCooldownMixin extends EndPortalBlockEntity {
     @Inject(method="needsCooldownBeforeTeleporting", at=@At("RETURN"), cancellable = true)
     private void suppressCooldown(CallbackInfoReturnable<Boolean> cir) {
         if (!FractalSimpleSettings.endGatewayCooldown) {

--- a/src/main/java/com/fractalsmp/fractal_carpet_addon/mixins/EndSpikeFeature_generationMixin.java
+++ b/src/main/java/com/fractalsmp/fractal_carpet_addon/mixins/EndSpikeFeature_generationMixin.java
@@ -1,0 +1,40 @@
+package com.fractalsmp.fractal_carpet_addon.mixins;
+
+import com.fractalsmp.fractal_carpet_addon.FractalSimpleSettings;
+import com.mojang.datafixers.Dynamic;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorld;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.chunk.ChunkGeneratorConfig;
+import net.minecraft.world.gen.feature.EndSpikeFeature;
+import net.minecraft.world.gen.feature.EndSpikeFeatureConfig;
+import net.minecraft.world.gen.feature.Feature;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Random;
+import java.util.function.Function;
+
+@Mixin(EndSpikeFeature.class)
+public abstract class EndSpikeFeature_generationMixin extends Feature<EndSpikeFeatureConfig> {
+    public EndSpikeFeature_generationMixin(Function<Dynamic<?>, ? extends EndSpikeFeatureConfig> configDeserializer) {
+        super(configDeserializer);
+    }
+
+    @Inject(method="generate", at = @At("HEAD"), cancellable = true)
+    public void suppressGenerate(IWorld iWorld, ChunkGenerator<? extends ChunkGeneratorConfig> chunkGenerator, Random random, BlockPos blockPos, EndSpikeFeatureConfig endSpikeFeatureConfig, CallbackInfoReturnable<Boolean> ci) {
+        if (!FractalSimpleSettings.endMainIslandStructureGen) {
+            ci.setReturnValue(true);
+        }
+    }
+
+    @Inject(method="generateSpike", at=@At("HEAD"), cancellable = true)
+    public void suppressGenerateSpike(IWorld world, Random random, EndSpikeFeatureConfig config, EndSpikeFeature.Spike spike, CallbackInfo ci) {
+        if (!FractalSimpleSettings.endMainIslandStructureGen) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/fractalsmp/fractal_carpet_addon/mixins/FightManager_structureGeneration.java
+++ b/src/main/java/com/fractalsmp/fractal_carpet_addon/mixins/FightManager_structureGeneration.java
@@ -1,0 +1,84 @@
+package com.fractalsmp.fractal_carpet_addon.mixins;
+
+import com.fractalsmp.fractal_carpet_addon.FractalSimpleSettings;
+import net.minecraft.entity.boss.ServerBossBar;
+import net.minecraft.entity.boss.dragon.EnderDragonFight;
+import net.minecraft.entity.boss.dragon.EnderDragonSpawnState;
+import net.minecraft.entity.decoration.EnderCrystalEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+import static net.minecraft.entity.boss.dragon.EnderDragonSpawnState.SUMMONING_DRAGON;
+
+@Mixin(EnderDragonFight.class)
+public abstract class FightManager_structureGeneration {
+
+    @Shadow private EnderDragonSpawnState dragonSpawnState;
+    @Shadow private ServerBossBar bossBar;
+    @Shadow protected abstract void setSpawnState(EnderDragonSpawnState enderDragonSpawnState);
+
+    private EnderDragonSpawnState tempDragonSpawnState;
+
+
+    /*@Redirect(method="tick", at=@At(value = "INVOKE", target = "Lnet/minecraft/entity/boss/dragon/EnderDragonSpawnState;run(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/entity/boss/dragon/EnderDragonFight;Ljava/util/List;ILnet/minecraft/util/math/BlockPos;)V"))
+    public void decideIfRun(EnderDragonSpawnState enderDragonSpawnState, ServerWorld world, EnderDragonFight fight, List<EnderCrystalEntity> crystals, int i, BlockPos blockPos) {
+        if (FractalSimpleSettings.endMainIslandStructureGen) {
+            //this.dragonSpawnState.run(world, fight, crystals, i, blockPos);
+        }
+    }*/
+
+    @Inject(method="tick", at=@At("HEAD"))
+    public void suppressTowerExplosionAndBlockDeletion(CallbackInfo ci) {
+        if (!FractalSimpleSettings.endMainIslandStructureGen
+            && !this.bossBar.getPlayers().isEmpty()
+            && this.dragonSpawnState != null
+            && this.dragonSpawnState == EnderDragonSpawnState.SUMMONING_PILLARS) {
+            this.setSpawnState(SUMMONING_DRAGON);   // THE ORDER OF THESE STATEMENTS IS VERY IMPORTANT
+            tempDragonSpawnState = dragonSpawnState;
+            dragonSpawnState = null;
+
+        }
+    }
+
+    @Inject(method="tick", at=@At("RETURN"))
+    public void suppressTowerExplosionAndBlockDeletionCleanup(CallbackInfo ci) {
+        if (tempDragonSpawnState != null) {
+            dragonSpawnState = tempDragonSpawnState;
+            tempDragonSpawnState = null;
+        }
+    }
+
+    private void cancelIfFeatureFalse(CallbackInfo ci) {
+        if (!FractalSimpleSettings.endMainIslandStructureGen) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method="generateEndGateway", at=@At("HEAD"), cancellable = true)
+    public void suppressGateway(CallbackInfo callbackInfo) {
+        cancelIfFeatureFalse(callbackInfo);
+    }
+
+    @Inject(method="generateEndGateway", at=@At("HEAD"), cancellable = true)
+    public void suppressGateway2(BlockPos blockPos, CallbackInfo callbackInfo) {
+        cancelIfFeatureFalse(callbackInfo);
+    }
+
+    @Inject(method="generateEndPortal", at=@At("HEAD"), cancellable = true)
+    public void suppressEndPortal(boolean previouslyKilled, CallbackInfo ci) {
+        cancelIfFeatureFalse(ci);
+    }
+
+    @Inject(method="resetEndCrystals", at=@At("HEAD"), cancellable = true)
+    public void suppressEndCrystals(CallbackInfo ci) {
+        cancelIfFeatureFalse(ci);
+    }
+}

--- a/src/main/java/com/fractalsmp/fractal_carpet_addon/mixins/MinecraftClient_noopMixin.java
+++ b/src/main/java/com/fractalsmp/fractal_carpet_addon/mixins/MinecraftClient_noopMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MinecraftClient.class)
-public class MinecraftClient_noopMixin {
+public abstract class MinecraftClient_noopMixin {
     @Inject(method = "<init>", at = @At("RETURN"))
     private void loadExtension(CallbackInfo ci) {
         FractalExtension.noop();

--- a/src/main/java/com/fractalsmp/fractal_carpet_addon/mixins/MinecraftServer_noopMixin.java
+++ b/src/main/java/com/fractalsmp/fractal_carpet_addon/mixins/MinecraftServer_noopMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MinecraftServer.class)
-public class MinecraftServer_noopMixin {
+public abstract class MinecraftServer_noopMixin {
     @Inject(method = "<init>", at=@At("RETURN"))
     private void loadExtension(CallbackInfo ci) {
         FractalExtension.noop();

--- a/src/main/resources/modid.mixins.json
+++ b/src/main/resources/modid.mixins.json
@@ -4,6 +4,8 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "EndGateway_noCooldownMixin",
+    "EndSpikeFeature_generationMixin",
+    "FightManager_structureGeneration",
     "MinecraftServer_noopMixin"
   ],
   "client": [


### PR DESCRIPTION
carpet rule endMainIslandStructureGen turns off ALL structure generation on the main end island besides the island itself.
If the code looks good approve, then we will merge to dev and start testing